### PR TITLE
Install tox for test Action

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install tox==3.14.5
     - name: Build
       run: |
         tox -e build


### PR DESCRIPTION
The base environment doesn't come with tox, and there's no point explicitly installing requirements because this project uses tox to do that